### PR TITLE
Add block filtering feature with whitelist and blacklist settings

### DIFF
--- a/src/main/java/dev/twme/debugstickpro/DebugStickPro.java
+++ b/src/main/java/dev/twme/debugstickpro/DebugStickPro.java
@@ -1,6 +1,16 @@
 package dev.twme.debugstickpro;
 
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
+
 import com.github.retrooper.packetevents.PacketEvents;
+
 import dev.twme.debugstickpro.blockdatautil.BlockDataSeparater;
 import dev.twme.debugstickpro.commands.MainCommand;
 import dev.twme.debugstickpro.commands.MainCommandTabComplete;
@@ -9,7 +19,22 @@ import dev.twme.debugstickpro.config.ConfigLoader;
 import dev.twme.debugstickpro.display.ActionBarDisplayTask;
 import dev.twme.debugstickpro.hook.CoreProtectUtil;
 import dev.twme.debugstickpro.hook.PlaceholderAPIUtil;
-import dev.twme.debugstickpro.listeners.*;
+import dev.twme.debugstickpro.listeners.BlockBreakEventListener;
+import dev.twme.debugstickpro.listeners.BlockPlaceEventListenerCanBuildChecker;
+import dev.twme.debugstickpro.listeners.ChunkLoadEventListener;
+import dev.twme.debugstickpro.listeners.ChunkUnloadEventListener;
+import dev.twme.debugstickpro.listeners.FreezeBlockIsolationListener;
+import dev.twme.debugstickpro.listeners.LeftClickListener;
+import dev.twme.debugstickpro.listeners.PlayerChangeDebugStickModeEventListener;
+import dev.twme.debugstickpro.listeners.PlayerChangedWorldEventListener;
+import dev.twme.debugstickpro.listeners.PlayerDropItemListener;
+import dev.twme.debugstickpro.listeners.PlayerItemHeldListener;
+import dev.twme.debugstickpro.listeners.PlayerJoinListener;
+import dev.twme.debugstickpro.listeners.PlayerLocaleChangeEventListener;
+import dev.twme.debugstickpro.listeners.PlayerQuitListener;
+import dev.twme.debugstickpro.listeners.PlayerSwapHandItemsEventListener;
+import dev.twme.debugstickpro.listeners.RightClickListener;
+import dev.twme.debugstickpro.listeners.WorldUnloadEventListener;
 import dev.twme.debugstickpro.localization.LangFileManager;
 import dev.twme.debugstickpro.localization.PlayerLanguageManager;
 import dev.twme.debugstickpro.mode.freeze.FreezeBlockManager;
@@ -22,14 +47,6 @@ import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder
 import me.tofaa.entitylib.APIConfig;
 import me.tofaa.entitylib.EntityLib;
 import me.tofaa.entitylib.spigot.SpigotEntityLibPlatform;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitScheduler;
-
-import java.util.UUID;
 
 public final class DebugStickPro extends JavaPlugin {
     /**
@@ -46,7 +63,7 @@ public final class DebugStickPro extends JavaPlugin {
     /**
      * This is the version of the plugin
      */
-    public static final int CONFIG_VERSION = 6;
+    public static final int CONFIG_VERSION = 7;
 
     /**
      * This is the version of the language file

--- a/src/main/java/dev/twme/debugstickpro/config/ConfigFile.java
+++ b/src/main/java/dev/twme/debugstickpro/config/ConfigFile.java
@@ -1,10 +1,11 @@
 package dev.twme.debugstickpro.config;
 
-import net.kyori.adventure.text.Component;
-import org.bukkit.Material;
-
 import java.util.ArrayList;
 import java.util.HashSet;
+
+import org.bukkit.Material;
+
+import net.kyori.adventure.text.Component;
 
 public class ConfigFile {
 
@@ -47,6 +48,18 @@ public class ConfigFile {
 
     public static class AutoRegionProtection {
         public static boolean Enabled;
+    }
+
+    public static class BlockFilter {
+        public static class Whitelist {
+            public static boolean Enabled;
+            public static HashSet<String> Blocks;
+        }
+
+        public static class Blacklist {
+            public static boolean Enabled;
+            public static HashSet<String> Blocks;
+        }
     }
 
     public static class BlockDataFilter {

--- a/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
+++ b/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
@@ -1,18 +1,19 @@
 package dev.twme.debugstickpro.config;
 
-import dev.twme.debugstickpro.DebugStickPro;
-import dev.twme.debugstickpro.utils.Log;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.minimessage.MiniMessage;
-import org.bukkit.Material;
-import org.bukkit.configuration.file.YamlConfiguration;
-
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import dev.twme.debugstickpro.DebugStickPro;
+import dev.twme.debugstickpro.utils.Log;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 
 public class ConfigLoader {
     private final static ConfigLoader instance = new ConfigLoader();
@@ -95,6 +96,11 @@ public class ConfigLoader {
         ConfigFile.BlacklistWorlds.Worlds = new HashSet<>(config.getStringList("BlacklistWorlds.Worlds"));
 
         ConfigFile.AutoRegionProtection.Enabled = config.getBoolean("AutoRegionProtection.Enabled");
+
+        ConfigFile.BlockFilter.Whitelist.Enabled = config.getBoolean("BlockFilter.Whitelist.Enabled");
+        ConfigFile.BlockFilter.Whitelist.Blocks = new HashSet<>(config.getStringList("BlockFilter.Whitelist.Blocks"));
+        ConfigFile.BlockFilter.Blacklist.Enabled = config.getBoolean("BlockFilter.Blacklist.Enabled");
+        ConfigFile.BlockFilter.Blacklist.Blocks = new HashSet<>(config.getStringList("BlockFilter.Blacklist.Blocks"));
 
         ConfigFile.BlockDataFilter.Whitelist.Enabled = config.getBoolean("BlockDataFilter.Whitelist.Enabled");
         ConfigFile.BlockDataFilter.Whitelist.Whitelist = new HashSet<>(config.getStringList("BlockDataFilter.Whitelist.Whitelist"));

--- a/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicLeftClick.java
+++ b/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicLeftClick.java
@@ -26,7 +26,7 @@ public class ClassicLeftClick {
             return;
         }
 
-        if (!BlockFilterUtil.isAllowed(playerUUID, block)) {
+        if (!BlockFilterUtil.isAllowed(player, block)) {
             return;
         }
 

--- a/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicLeftClick.java
+++ b/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicLeftClick.java
@@ -1,14 +1,16 @@
 package dev.twme.debugstickpro.mode.classic;
 
-import dev.twme.debugstickpro.blockdatautil.BlockDataSeparater;
-import dev.twme.debugstickpro.blockdatautil.SubBlockData;
-import dev.twme.debugstickpro.playerdata.PlayerData;
+import java.util.ArrayList;
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.UUID;
+import dev.twme.debugstickpro.blockdatautil.BlockDataSeparater;
+import dev.twme.debugstickpro.blockdatautil.SubBlockData;
+import dev.twme.debugstickpro.playerdata.PlayerData;
+import dev.twme.debugstickpro.utils.BlockFilterUtil;
 
 public class ClassicLeftClick {
 
@@ -21,6 +23,10 @@ public class ClassicLeftClick {
         Block block = player.getTargetBlockExact(5);
 
         if (block == null) {
+            return;
+        }
+
+        if (!BlockFilterUtil.isAllowed(playerUUID, block)) {
             return;
         }
 

--- a/src/main/java/dev/twme/debugstickpro/mode/copy/CopyLeftClick.java
+++ b/src/main/java/dev/twme/debugstickpro/mode/copy/CopyLeftClick.java
@@ -1,19 +1,20 @@
 package dev.twme.debugstickpro.mode.copy;
 
-import dev.twme.debugstickpro.blockdatautil.BlockDataSeparater;
-import dev.twme.debugstickpro.blockdatautil.SubBlockData;
-import dev.twme.debugstickpro.events.CopyModeCopyBlockDataEvent;
-import dev.twme.debugstickpro.playerdata.PlayerData;
-import dev.twme.debugstickpro.playerdata.PlayerDataManager;
-import dev.twme.debugstickpro.utils.AutoCheckCanChangeUtil;
+import java.util.ArrayList;
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.UUID;
+import dev.twme.debugstickpro.blockdatautil.BlockDataSeparater;
+import dev.twme.debugstickpro.blockdatautil.SubBlockData;
+import dev.twme.debugstickpro.events.CopyModeCopyBlockDataEvent;
+import dev.twme.debugstickpro.playerdata.PlayerData;
+import dev.twme.debugstickpro.playerdata.PlayerDataManager;
+import dev.twme.debugstickpro.utils.AutoCheckCanChangeUtil;
 
 public class CopyLeftClick {
     public static void onLeftClick(UUID playerUUID, PlayerData playerData) {

--- a/src/main/java/dev/twme/debugstickpro/utils/AutoCheckCanChangeUtil.java
+++ b/src/main/java/dev/twme/debugstickpro/utils/AutoCheckCanChangeUtil.java
@@ -20,11 +20,11 @@ public final class AutoCheckCanChangeUtil {
      */
     public static boolean canChange(UUID playerUUID, Block block) {
         Player player = Bukkit.getPlayer(playerUUID);
-        World world = block.getWorld();
-
-        if (player.hasPermission("debugstickpro.bypassregion")) {
-            return true;
+        if (player == null) {
+            return false;
         }
+
+        World world = block.getWorld();
 
         boolean canChange = true;
 
@@ -44,18 +44,14 @@ public final class AutoCheckCanChangeUtil {
             }
         }
 
-        if (ConfigFile.AutoRegionProtection.Enabled) {
-            if (canChange) {
-                if (!BlockPlaceEventListenerCanBuildChecker.canBuild(block, playerUUID)) {
-                    canChange = false;
-                }
+        if (ConfigFile.AutoRegionProtection.Enabled && canChange && !player.hasPermission("debugstickpro.bypassregion")) {
+            if (!BlockPlaceEventListenerCanBuildChecker.canBuild(block, playerUUID)) {
+                canChange = false;
             }
         }
 
-        if (canChange) {
-            if (!BlockFilterUtil.isAllowed(playerUUID, block)) {
-                canChange = false;
-            }
+        if (canChange && !BlockFilterUtil.isAllowed(player, block)) {
+            canChange = false;
         }
 
         return canChange;

--- a/src/main/java/dev/twme/debugstickpro/utils/AutoCheckCanChangeUtil.java
+++ b/src/main/java/dev/twme/debugstickpro/utils/AutoCheckCanChangeUtil.java
@@ -1,13 +1,14 @@
 package dev.twme.debugstickpro.utils;
 
-import dev.twme.debugstickpro.config.ConfigFile;
-import dev.twme.debugstickpro.listeners.BlockPlaceEventListenerCanBuildChecker;
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-import java.util.UUID;
+import dev.twme.debugstickpro.config.ConfigFile;
+import dev.twme.debugstickpro.listeners.BlockPlaceEventListenerCanBuildChecker;
 
 public final class AutoCheckCanChangeUtil {
     /**
@@ -48,6 +49,12 @@ public final class AutoCheckCanChangeUtil {
                 if (!BlockPlaceEventListenerCanBuildChecker.canBuild(block, playerUUID)) {
                     canChange = false;
                 }
+            }
+        }
+
+        if (canChange) {
+            if (!BlockFilterUtil.isAllowed(playerUUID, block)) {
+                canChange = false;
             }
         }
 

--- a/src/main/java/dev/twme/debugstickpro/utils/BlockFilterUtil.java
+++ b/src/main/java/dev/twme/debugstickpro/utils/BlockFilterUtil.java
@@ -2,6 +2,7 @@ package dev.twme.debugstickpro.utils;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
@@ -12,17 +13,16 @@ public final class BlockFilterUtil {
     /**
      * Check if the block is allowed by the BlockFilter settings.
      *
-     * @param playerUUID player UUID
-     * @param block      the block to check
+     * @param player the player to check
+     * @param block the block to check
      * @return true if the block is allowed, false if it is filtered out
      */
-    public static boolean isAllowed(UUID playerUUID, Block block) {
-        Player player = org.bukkit.Bukkit.getPlayer(playerUUID);
+    public static boolean isAllowed(Player player, Block block) {
         if (player == null) {
             return false;
         }
 
-        // bypass permission
+        // Bypass permission applies to both whitelist and blacklist.
         if (player.hasPermission("debugstickpro.bypassblockfilter")) {
             return true;
         }
@@ -46,5 +46,9 @@ public final class BlockFilterUtil {
         }
 
         return true;
+    }
+
+    public static boolean isAllowed(UUID playerUUID, Block block) {
+        return isAllowed(Bukkit.getPlayer(playerUUID), block);
     }
 }

--- a/src/main/java/dev/twme/debugstickpro/utils/BlockFilterUtil.java
+++ b/src/main/java/dev/twme/debugstickpro/utils/BlockFilterUtil.java
@@ -1,0 +1,50 @@
+package dev.twme.debugstickpro.utils;
+
+import java.util.UUID;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+import dev.twme.debugstickpro.config.ConfigFile;
+
+public final class BlockFilterUtil {
+
+    /**
+     * Check if the block is allowed by the BlockFilter settings.
+     *
+     * @param playerUUID player UUID
+     * @param block      the block to check
+     * @return true if the block is allowed, false if it is filtered out
+     */
+    public static boolean isAllowed(UUID playerUUID, Block block) {
+        Player player = org.bukkit.Bukkit.getPlayer(playerUUID);
+        if (player == null) {
+            return false;
+        }
+
+        // bypass permission
+        if (player.hasPermission("debugstickpro.bypassblockfilter")) {
+            return true;
+        }
+
+        String materialName = block.getType().name();
+
+        // Whitelist check
+        if (ConfigFile.BlockFilter.Whitelist.Enabled) {
+            boolean inWhitelist = ConfigFile.BlockFilter.Whitelist.Blocks.contains("*")
+                    || ConfigFile.BlockFilter.Whitelist.Blocks.contains(materialName);
+            if (!inWhitelist) {
+                return false;
+            }
+        }
+
+        // Blacklist check (takes precedence)
+        if (ConfigFile.BlockFilter.Blacklist.Enabled) {
+            if (ConfigFile.BlockFilter.Blacklist.Blocks.contains(materialName)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -87,6 +87,7 @@ BlockDataFilter:
       - "WaterloggedData"
 
 BlockFilter:
+  # Permission bypass for both whitelist and blacklist: debugstickpro.bypassblockfilter
   Whitelist:
     # If enabled, the debug stick will only work on the specified blocks.
     Enabled: false
@@ -96,7 +97,6 @@ BlockFilter:
   Blacklist:
     # If enabled, the debug stick will not work on the specified blocks.
     # This option takes precedence over the whitelist.
-    # Permission bypass: debugstickpro.bypassblockfilter
     Enabled: false
     # Options to fill: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
     Blocks:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Don't touch this value
-ConfigVersion: 6
+ConfigVersion: 7
 
 Language:
   # Language files are located in the "lang" folder.
@@ -85,6 +85,23 @@ BlockDataFilter:
     Blacklist:
       - "AgeableData"
       - "WaterloggedData"
+
+BlockFilter:
+  Whitelist:
+    # If enabled, the debug stick will only work on the specified blocks.
+    Enabled: false
+    # Options to fill: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
+    Blocks:
+      - "*"
+  Blacklist:
+    # If enabled, the debug stick will not work on the specified blocks.
+    # This option takes precedence over the whitelist.
+    # Permission bypass: debugstickpro.bypassblockfilter
+    Enabled: false
+    # Options to fill: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
+    Blocks:
+      - "BEDROCK"
+      - "BARRIER"
 
 ModeSetting:
   ClassicMode:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -59,6 +59,9 @@ permissions:
     default: op
     # Per-type bypass pattern:
     # debugstickpro.bypassblacklist.<subblockdatatype-lowercase>
+  debugstickpro.bypassblockfilter:
+    description: Allows bypass block material filter (BlockFilter whitelist/blacklist)
+    default: op
   debugstickpro.basic:
     description: Allows basic usage of the DebugStickPro
     default: op
@@ -77,3 +80,4 @@ permissions:
       - debugstickpro.reload
       - debugstickpro.bypassregion
       - debugstickpro.bypassblacklist
+      - debugstickpro.bypassblockfilter

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -60,7 +60,7 @@ permissions:
     # Per-type bypass pattern:
     # debugstickpro.bypassblacklist.<subblockdatatype-lowercase>
   debugstickpro.bypassblockfilter:
-    description: Allows bypass block material filter (BlockFilter whitelist/blacklist)
+    description: Allows bypassing the BlockFilter whitelist and blacklist
     default: op
   debugstickpro.basic:
     description: Allows basic usage of the DebugStickPro


### PR DESCRIPTION
Introduce a block filtering mechanism that allows users to configure whitelists and blacklists for block interactions. This feature enhances control over which blocks can be manipulated using the debug stick. Update the configuration version to accommodate these changes.