### PR TITLE
perf: reduce action bar and localization overhead

### DIFF
--- a/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
+++ b/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
@@ -69,6 +69,7 @@ public class ConfigLoader {
 
     private void loadValues() {
 
+        ConfigFile.Language.LangFiles.clear();
         ConfigFile.Language.LangFiles.addAll(config.getStringList("Language.LangFiles"));
         ConfigFile.Language.DefaultLanguage = config.getString("Language.DefaultLanguage");
 

--- a/src/main/java/dev/twme/debugstickpro/display/ActionBarDisplayTask.java
+++ b/src/main/java/dev/twme/debugstickpro/display/ActionBarDisplayTask.java
@@ -10,30 +10,30 @@ import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.UUID;
 
 public class ActionBarDisplayTask implements Runnable {
     @Override
     public void run() {
-        for (UUID uuid : new HashSet<>(PlayerDataManager.getDisplaySet())) {
+        Iterator<UUID> iterator = PlayerDataManager.getDisplaySet().iterator();
+        while (iterator.hasNext()) {
+            UUID uuid = iterator.next();
             Player player = Bukkit.getPlayer(uuid);
-
-            Block block;
 
             // player is offline or something
             if (player == null) {
+                iterator.remove();
                 continue;
             }
-            block = player.getTargetBlockExact(5);
 
             if (!player.hasPermission("debugstickpro.use")) {
-                PlayerDataManager.removePlayerFromDisplayList(uuid);
+                removeFromDisplayList(iterator, uuid);
                 continue;
             }
 
             if (!DebugStickItem.checkPlayer(player)) {
-                PlayerDataManager.removePlayerFromDisplayList(uuid);
+                removeFromDisplayList(iterator, uuid);
                 continue;
             }
 
@@ -41,6 +41,7 @@ public class ActionBarDisplayTask implements Runnable {
 
             switch (playerData.getDebugStickMode()) {
                 case CLASSIC:
+                    Block block = player.getTargetBlockExact(5);
                     if (block == null) {
                         ActionbarUtil.removeActionBar(uuid);
                         continue;
@@ -55,5 +56,10 @@ public class ActionBarDisplayTask implements Runnable {
                     continue;
             }
         }
+    }
+
+    private void removeFromDisplayList(Iterator<UUID> iterator, UUID uuid) {
+        iterator.remove();
+        ActionbarUtil.removeActionBar(uuid);
     }
 }

--- a/src/main/java/dev/twme/debugstickpro/display/ActionbarUtil.java
+++ b/src/main/java/dev/twme/debugstickpro/display/ActionbarUtil.java
@@ -10,7 +10,9 @@ import java.util.UUID;
 
 public class ActionbarUtil {
 
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
     private static final Set<UUID> lastIsRemove = new java.util.HashSet<>();
+
     public static void removeActionBar(UUID uuid) {
         Player player = Bukkit.getPlayer(uuid);
         if (lastIsRemove.contains(uuid)) {
@@ -23,8 +25,7 @@ public class ActionbarUtil {
     }
 
     public static void sendActionBar(Player player, String message) {
-        var mm = MiniMessage.miniMessage();
-        Component parsed = mm.deserialize(message);
+        Component parsed = MINI_MESSAGE.deserialize(message);
         player.sendActionBar(parsed);
         lastIsRemove.remove(player.getUniqueId());
     }

--- a/src/main/java/dev/twme/debugstickpro/localization/LangFileReader.java
+++ b/src/main/java/dev/twme/debugstickpro/localization/LangFileReader.java
@@ -22,13 +22,15 @@ public class LangFileReader {
     /**
      * This is the cache of the language file
      */
-    private static HashMap<String,String> cache = new HashMap<>();
+    private static final HashMap<String, String> cache = new HashMap<>();
+    private static final HashMap<String, String> optionalStringCache = new HashMap<>();
 
     /**
      * Clear the cache of the language file
      */
     public static void clearCache() {
         cache.clear();
+        optionalStringCache.clear();
     }
 
     /**
@@ -99,15 +101,19 @@ public class LangFileReader {
      */
     public String getString(String key) {
 
-        if (cache.containsKey(locale + key)) {
-            return cache.get(locale + key);
+        String cacheKey = cacheKey(key);
+        if (cache.containsKey(cacheKey)) {
+            return cache.get(cacheKey);
         }
 
+        String value;
         try {
-            if (this.langFile.getString(key) == null) {
+            value = this.langFile.getString(key);
+            if (value == null) {
                 set(key, LangFileManager.getLang("en_US").getString(key));
                 Log.warning("Missing key: " + key + " in " + locale + ".yml");
-                if (this.langFile.getString(key) == null) {
+                value = this.langFile.getString(key);
+                if (value == null) {
                     LangFileManager.getLang("en_US").set(key, "Missing...");
                     return "Missing key: \"" + key + "\" in en_US.yml";
                 }
@@ -117,8 +123,8 @@ public class LangFileReader {
             return "Missing key: \"" + key + "\"" + " in " + locale + ".yml";
         }
 
-        cache.put(locale + key, this.langFile.getString(key));
-        return this.langFile.getString(key);
+        cache.put(cacheKey, value);
+        return value;
     }
 
     /**
@@ -128,7 +134,14 @@ public class LangFileReader {
      * @return the string of the key, or null if it is not configured
      */
     public String getOptionalString(String key) {
-        return this.langFile.getString(key);
+        String cacheKey = cacheKey(key);
+        if (optionalStringCache.containsKey(cacheKey)) {
+            return optionalStringCache.get(cacheKey);
+        }
+
+        String value = this.langFile.getString(key);
+        optionalStringCache.put(cacheKey, value);
+        return value;
     }
 
     /**
@@ -164,7 +177,13 @@ public class LangFileReader {
      */
     public void set(String path, Object value) {
         this.langFile.set(path, value);
+        cache.remove(cacheKey(path));
+        optionalStringCache.remove(cacheKey(path));
         save();
+    }
+
+    private String cacheKey(String key) {
+        return locale + ":" + key;
     }
 
     /**

--- a/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicActionBarDisplay.java
+++ b/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicActionBarDisplay.java
@@ -47,20 +47,24 @@ public class ClassicActionBarDisplay {
         }
 
         int sort = 0;
+        int displayListSize = displayList.size();
         if (ConfigFile.ActionBarDisplay.AutoToCenter) {
-            sort = selectedIndex - displayList.size() / 2 + 1 + displayList.size() - (displayList.size() % 2);
+            sort = selectedIndex - displayListSize / 2 + 1 + displayListSize - (displayListSize % 2);
         }
 
         // 排序顯示順序
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new StringBuilder(displayListSize * 32);
+        String selectedDataFormat = I18n.string(playerUUID, Lang.ActionBar.SelectedDataFormat);
+        String notSelectedDataFormat = I18n.string(playerUUID, Lang.ActionBar.NotSelectedDataFormat);
 
-        for (int i = 0; i < displayList.size(); i++) {
-            SubBlockData subBlockData = displayList.get((i + sort) % displayList.size());
+        for (int i = 0; i < displayListSize; i++) {
+            SubBlockData subBlockData = displayList.get((i + sort) % displayListSize);
             String value = I18n.blockDataValue(playerUUID, subBlockData);
+            String dataName = I18n.string(playerUUID, subBlockData.dataName());
             if (subBlockData.isUsing()) {
-                stringBuilder.append(Lang.ActionBar.formatSelectedData(I18n.string(playerUUID, Lang.ActionBar.SelectedDataFormat), I18n.string(playerUUID, subBlockData.dataName()), value)).append(" ");
+                stringBuilder.append(Lang.ActionBar.formatSelectedData(selectedDataFormat, dataName, value)).append(" ");
             } else {
-                stringBuilder.append(Lang.ActionBar.formatNotSelectedData(I18n.string(playerUUID, Lang.ActionBar.NotSelectedDataFormat), I18n.string(playerUUID, subBlockData.dataName()), value)).append(" ");
+                stringBuilder.append(Lang.ActionBar.formatNotSelectedData(notSelectedDataFormat, dataName, value)).append(" ");
             }
         }
         return stringBuilder.toString();

--- a/src/main/java/dev/twme/debugstickpro/utils/DebugStickItem.java
+++ b/src/main/java/dev/twme/debugstickpro/utils/DebugStickItem.java
@@ -10,6 +10,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 
 public final class DebugStickItem {
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
+
     public static boolean isDebugStickItem(ItemStack item) {
         if (item == null) {
             return false;
@@ -17,10 +19,11 @@ public final class DebugStickItem {
         if (item.getType() != ConfigFile.DebugStickItem.Material) {
             return false;
         }
-        if (item.getItemMeta() == null) {
+        ItemMeta itemMeta = item.getItemMeta();
+        if (itemMeta == null) {
             return false;
         }
-        if (!item.getItemMeta().getPersistentDataContainer().has(PersistentKeys.DEBUG_STICK_ITEM)) {
+        if (!itemMeta.getPersistentDataContainer().has(PersistentKeys.DEBUG_STICK_ITEM)) {
             return false;
         }
         return true;
@@ -34,8 +37,7 @@ public final class DebugStickItem {
     public static ItemStack getDebugStickItem() {
         ItemStack itemStack = new ItemStack(ConfigFile.DebugStickItem.Material);
         ItemMeta itemMeta = itemStack.getItemMeta();
-        MiniMessage mm = MiniMessage.miniMessage();
-        Component displayName = mm.deserialize(ConfigFile.DebugStickItem.DisplayName);
+        Component displayName = MINI_MESSAGE.deserialize(ConfigFile.DebugStickItem.DisplayName);
         itemMeta.displayName(displayName);
         itemMeta.lore(ConfigFile.DebugStickItem.Lore);
         itemMeta.getPersistentDataContainer().set(PersistentKeys.DEBUG_STICK_ITEM, PersistentDataType.STRING, "debugstickpro");


### PR DESCRIPTION
## Summary
- reduce per-update overhead in the action bar task by avoiding display-set copies and only ray tracing target blocks for classic mode
- cache optional localization lookups used by BlockData value translations and reduce repeated format lookups while rendering classic action bars
- clear configured language files before reload to prevent duplicated static config entries
- reuse MiniMessage instances and avoid duplicate ItemMeta reads for debug stick checks

## Tests
- mvn test
- mvn package
- git diff --check