### PR TITLE
Fix debug stick mode command behavior

### DIFF
--- a/src/main/java/dev/twme/debugstickpro/commands/subcommands/ModeCommand.java
+++ b/src/main/java/dev/twme/debugstickpro/commands/subcommands/ModeCommand.java
@@ -7,11 +7,13 @@ import dev.twme.debugstickpro.playerdata.DebugStickMode;
 import dev.twme.debugstickpro.playerdata.PlayerData;
 import dev.twme.debugstickpro.playerdata.PlayerDataManager;
 import dev.twme.debugstickpro.utils.CustomModelDataManager;
+import dev.twme.debugstickpro.utils.DebugStickItem;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.Locale;
 import java.util.UUID;
 
 public class ModeCommand {
@@ -43,62 +45,64 @@ public class ModeCommand {
         if (args.length != 2) {
             return false;
         }
-        PlayerData playerData = PlayerDataManager.getOrCreatePlayerData(player.getUniqueId());
-        if (args[1].equalsIgnoreCase("classic")) {
 
+        DebugStickMode newMode = parseMode(args[1]);
 
-            if (modeChangeEventCancelled(player.getUniqueId(), playerData.getDebugStickMode(), DebugStickMode.CLASSIC)) {
-                return true;
-            }
-
-            PlayerDataManager.setPlayerData(player.getUniqueId(), playerData.setDebugStickMode(DebugStickMode.CLASSIC));
-
-            CustomModelDataManager.updateItem(player, DebugStickMode.CLASSIC);
-
-            Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.Mode.SuccessSetToClassic));
-            player.sendMessage(parsed);
-            return true;
-        } else if (args[1].equalsIgnoreCase("copy")) {
-            if (player.hasPermission("debugstickpro.mode.copy")) {
-
-                if (modeChangeEventCancelled(player.getUniqueId(), playerData.getDebugStickMode(), DebugStickMode.COPY)) {
-                    return true;
-                }
-
-                PlayerDataManager.setPlayerData(player.getUniqueId(), playerData.setDebugStickMode(DebugStickMode.COPY));
-
-                CustomModelDataManager.updateItem(player, DebugStickMode.COPY);
-
-                Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.Mode.SuccessSetToCopy));
-                player.sendMessage(parsed);
-            } else {
-                Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.NoPermission));
-                player.sendMessage(parsed);
-            }
-            return true;
-        } else if (args[1].equalsIgnoreCase("freeze")) {
-            if (player.hasPermission("debugstickpro.mode.freeze")) {
-
-                if (modeChangeEventCancelled(player.getUniqueId(), playerData.getDebugStickMode(), DebugStickMode.FREEZE)) {
-                    return true;
-                }
-
-                PlayerDataManager.setPlayerData(player.getUniqueId(), playerData.setDebugStickMode(DebugStickMode.FREEZE));
-
-                CustomModelDataManager.updateItem(player, DebugStickMode.FREEZE);
-
-                Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.Mode.SuccessSetToFreeze));
-                player.sendMessage(parsed);
-            } else {
-                Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.NoPermission));
-                player.sendMessage(parsed);
-            }
-            return true;
-        } else {
+        if (newMode == null) {
             Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.Mode.Usage));
             player.sendMessage(parsed);
             return true;
         }
 
+        if (!hasModePermission(player, newMode)) {
+            Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.NoPermission));
+            player.sendMessage(parsed);
+            return true;
+        }
+
+        if (!DebugStickItem.checkPlayer(player)) {
+            Component parsed = mm.deserialize(I18n.string(playerUUID, Lang.CommandsMessages.Mode.MustHoldDebugStick));
+            player.sendMessage(parsed);
+            return true;
+        }
+
+        PlayerData playerData = PlayerDataManager.getOrCreatePlayerData(player.getUniqueId());
+
+        if (modeChangeEventCancelled(player.getUniqueId(), playerData.getDebugStickMode(), newMode)) {
+            return true;
+        }
+
+        PlayerDataManager.setPlayerData(player.getUniqueId(), playerData.setDebugStickMode(newMode));
+
+        CustomModelDataManager.updateItem(player, newMode);
+
+        Component parsed = mm.deserialize(I18n.string(playerUUID, successMessageKey(newMode)));
+        player.sendMessage(parsed);
+        return true;
+    }
+
+    private static DebugStickMode parseMode(String mode) {
+        return switch (mode.toLowerCase(Locale.ROOT)) {
+            case "classic" -> DebugStickMode.CLASSIC;
+            case "copy" -> DebugStickMode.COPY;
+            case "freeze" -> DebugStickMode.FREEZE;
+            default -> null;
+        };
+    }
+
+    private static boolean hasModePermission(Player player, DebugStickMode mode) {
+        return switch (mode) {
+            case CLASSIC -> true;
+            case COPY -> player.hasPermission("debugstickpro.mode.copy");
+            case FREEZE -> player.hasPermission("debugstickpro.mode.freeze");
+        };
+    }
+
+    private static String successMessageKey(DebugStickMode mode) {
+        return switch (mode) {
+            case CLASSIC -> Lang.CommandsMessages.Mode.SuccessSetToClassic;
+            case COPY -> Lang.CommandsMessages.Mode.SuccessSetToCopy;
+            case FREEZE -> Lang.CommandsMessages.Mode.SuccessSetToFreeze;
+        };
     }
 }

--- a/src/main/java/dev/twme/debugstickpro/display/ActionBarDisplayTask.java
+++ b/src/main/java/dev/twme/debugstickpro/display/ActionBarDisplayTask.java
@@ -42,11 +42,7 @@ public class ActionBarDisplayTask implements Runnable {
             switch (playerData.getDebugStickMode()) {
                 case CLASSIC:
                     Block block = player.getTargetBlockExact(5);
-                    if (block == null) {
-                        ActionbarUtil.removeActionBar(uuid);
-                        continue;
-                    }
-                    ActionbarUtil.sendActionBar(player, ClassicActionBarDisplay.getDisplay(uuid, block.getBlockData()));
+                    ActionbarUtil.sendActionBar(player, ClassicActionBarDisplay.getDisplay(uuid, block == null ? null : block.getBlockData()));
                     continue;
                 case COPY:
                     ActionbarUtil.sendActionBar(player, CopyActionBarDisplay.getDisplay(uuid));

--- a/src/main/java/dev/twme/debugstickpro/localization/Lang.java
+++ b/src/main/java/dev/twme/debugstickpro/localization/Lang.java
@@ -19,6 +19,7 @@ public class Lang {
 
         public final static class Mode {
             public final static String Usage = "CommandsMessages.Mode.Usage";
+            public final static String MustHoldDebugStick = "CommandsMessages.Mode.MustHoldDebugStick";
             public final static String SuccessSetToClassic = "CommandsMessages.Mode.SuccessSetToClassic";
             public final static String SuccessSetToCopy = "CommandsMessages.Mode.SuccessSetToCopy";
             public final static String SuccessSetToFreeze = "CommandsMessages.Mode.SuccessSetToFreeze";

--- a/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicActionBarDisplay.java
+++ b/src/main/java/dev/twme/debugstickpro/mode/classic/ClassicActionBarDisplay.java
@@ -14,6 +14,9 @@ import java.util.UUID;
 
 public class ClassicActionBarDisplay {
     public static String getDisplay(UUID playerUUID, BlockData blockData) {
+        if (blockData == null) {
+            return I18n.string(playerUUID, Lang.Tips.classicModeIntroduction);
+        }
 
         // 用於確認是否有任何 SubBlockData 類型被使用的變數
         boolean hasIsUsingType = false;
@@ -24,9 +27,8 @@ public class ClassicActionBarDisplay {
         // 獲取方塊拆分後的資料
         ArrayList<SubBlockData> displayList = BlockDataSeparater.separate(blockData, playerUUID);
 
-        // TODO: 需檢查這邊的返回是否是冗於
         if (displayList.isEmpty()) {
-            return " ";
+            return I18n.string(playerUUID, Lang.Tips.classicModeIntroduction);
         }
 
         int selectedIndex;

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -16,6 +16,7 @@ CommandsMessages:
         Success: "Given Debug Stick to %player%."
     Mode:
         Usage: "Usage: <b><u>/dsp mode [classic|copy|freeze]</u></b>"
+        MustHoldDebugStick: "You must hold a Debug Stick to change its mode."
         SuccessSetToClassic: "Mode set to <b><u>Classic</u></b>."
         SuccessSetToCopy: "Mode set to <b><u>Copy</u></b>."
         SuccessSetToFreeze: "Mode set to <b><u>Freeze</u></b>."

--- a/src/main/resources/lang/zh_TW.yml
+++ b/src/main/resources/lang/zh_TW.yml
@@ -17,6 +17,7 @@ CommandsMessages:
     Success: "已將除錯棒給予 %player%。"
   Mode:
     Usage: "用法: <b><u>/dsp mode [classic|copy|freeze]</u></b>"
+    MustHoldDebugStick: "您必須手持除錯棒才能更改其模式。"
     SuccessSetToClassic: "模式已設置為 <b><u>經典</u></b>。"
     SuccessSetToCopy: "模式已設置為 <b><u>複製</u></b>。"
     SuccessSetToFreeze: "模式已設置為 <b><u>凍結</u></b>。"


### PR DESCRIPTION
## Summary
- Show the classic mode introduction when no target block is found or the target block has no editable block data.
- Require players to hold a DebugStickPro debug stick before /dsp mode changes mode state.
- Add localized feedback for the hold-a-debug-stick requirement.

Fixes #35

## Tests
- mvn test