### PR TITLE
fix: prevent double-plant half duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@
 ### Configuration File:
 [config.yml](https://github.com/TWME-TW/DebugStickPro/blob/main/src/main/resources/config.yml)
 
+`BlockDataFilter.AllowUnsafeBisectedData` is disabled by default to prevent invalid
+double-block structures and duplicate drops. Enable it only when multi-block
+`Bisected` properties are intentionally needed.
+
 ### Language File:
 [lang](https://github.com/TWME-TW/DebugStickPro/tree/main/src/main/resources/lang)
 ### Permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
             <version>3.3.3+119e9e1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/dev/twme/debugstickpro/DebugStickPro.java
+++ b/src/main/java/dev/twme/debugstickpro/DebugStickPro.java
@@ -63,7 +63,7 @@ public final class DebugStickPro extends JavaPlugin {
     /**
      * This is the version of the plugin
      */
-    public static final int CONFIG_VERSION = 7;
+    public static final int CONFIG_VERSION = 8;
 
     /**
      * This is the version of the language file

--- a/src/main/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparater.java
+++ b/src/main/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparater.java
@@ -883,6 +883,10 @@ public class BlockDataSeparater {
     }
 
     static boolean isBisectedHalfSafeToModify(BlockData blockData) {
+        if (ConfigFile.BlockDataFilter.AllowUnsafeBisectedData) {
+            return blockData instanceof Bisected;
+        }
+
         // Stairs and trapdoors use half as a single-block placement property. Other
         // Bisected blocks depend on a matching block above or below; exposing half
         // lets one side become a second bottom half and duplicate its drops.

--- a/src/main/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparater.java
+++ b/src/main/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparater.java
@@ -222,7 +222,7 @@ public class BlockDataSeparater {
             blockDataList.add(bigDripleafData);
         }
 
-        if (blockData instanceof Bisected) {
+        if (isBisectedHalfSafeToModify(blockData)) {
             SubBlockData bisectedData = new BisectedData(blockData);
             blockDataList.add(bisectedData);
         }
@@ -880,5 +880,13 @@ public class BlockDataSeparater {
         cache.put(blockData.getMaterial(), blockDataList);
 
         return cloneForBlockData(blockDataList, blockData);
+    }
+
+    static boolean isBisectedHalfSafeToModify(BlockData blockData) {
+        // Stairs and trapdoors use half as a single-block placement property. Other
+        // Bisected blocks depend on a matching block above or below; exposing half
+        // lets one side become a second bottom half and duplicate its drops.
+        return blockData instanceof Bisected
+                && (blockData instanceof Stairs || blockData instanceof TrapDoor);
     }
 }

--- a/src/main/java/dev/twme/debugstickpro/config/ConfigFile.java
+++ b/src/main/java/dev/twme/debugstickpro/config/ConfigFile.java
@@ -63,6 +63,8 @@ public class ConfigFile {
     }
 
     public static class BlockDataFilter {
+        public static boolean AllowUnsafeBisectedData;
+
         public static class Whitelist {
             public static boolean Enabled;
             public static HashSet<String> Whitelist;

--- a/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
+++ b/src/main/java/dev/twme/debugstickpro/config/ConfigLoader.java
@@ -107,6 +107,7 @@ public class ConfigLoader {
         ConfigFile.BlockDataFilter.Whitelist.Whitelist = new HashSet<>(config.getStringList("BlockDataFilter.Whitelist.Whitelist"));
         ConfigFile.BlockDataFilter.Blacklist.Enabled = config.getBoolean("BlockDataFilter.Blacklist.Enabled");
         ConfigFile.BlockDataFilter.Blacklist.Blacklist = new HashSet<>(config.getStringList("BlockDataFilter.Blacklist.Blacklist"));
+        ConfigFile.BlockDataFilter.AllowUnsafeBisectedData = config.getBoolean("BlockDataFilter.AllowUnsafeBisectedData");
 
         ConfigFile.ModeSetting.ClassicMode.ClearSelectedDataTypeWhenModeChange = config.getBoolean("ModeSetting.ClassicMode.ClearSelectedDataTypeWhenModeChange");
         ConfigFile.ModeSetting.CopyMode.ClearStoredDataWhenModeChange = config.getBoolean("ModeSetting.CopyMode.ClearStoredDataWhenModeChange");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Don't touch this value
-ConfigVersion: 7
+ConfigVersion: 8
 
 Language:
   # Language files are located in the "lang" folder.
@@ -67,6 +67,10 @@ AutoRegionProtection:
   Enabled: true
 
 BlockDataFilter:
+  # If enabled, exposes the half property of multi-block structures such as doors
+  # and double plants. This can create invalid block pairs and duplicate drops.
+  # Default: false
+  AllowUnsafeBisectedData: false
   Whitelist:
     # If enabled, only the specified block data will be displayed.
     Enabled: false

--- a/src/test/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparaterTest.java
+++ b/src/test/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparaterTest.java
@@ -1,0 +1,47 @@
+package dev.twme.debugstickpro.blockdatautil;
+
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.type.PitcherCrop;
+import org.bukkit.block.data.type.SmallDripleaf;
+import org.bukkit.block.data.type.Stairs;
+import org.bukkit.block.data.type.TrapDoor;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BlockDataSeparaterTest {
+
+    @Test
+    public void allowsSingleBlockBisectedProperties() {
+        assertTrue(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Stairs.class)));
+        assertTrue(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(TrapDoor.class)));
+    }
+
+    @Test
+    public void rejectsMultiBlockBisectedProperties() {
+        assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Bisected.class)));
+        assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Door.class)));
+        assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(SmallDripleaf.class)));
+        assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(PitcherCrop.class)));
+    }
+
+    @Test
+    public void rejectsNonBisectedProperties() {
+        assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(BlockData.class)));
+    }
+
+    private static BlockData blockData(Class<? extends BlockData> type) {
+        return (BlockData) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxy, method, args) -> {
+                    throw new AssertionError("Unexpected BlockData method call: " + method.getName());
+                }
+        );
+    }
+}

--- a/src/test/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparaterTest.java
+++ b/src/test/java/dev/twme/debugstickpro/blockdatautil/BlockDataSeparaterTest.java
@@ -9,6 +9,8 @@ import org.bukkit.block.data.type.Stairs;
 import org.bukkit.block.data.type.TrapDoor;
 import org.junit.Test;
 
+import dev.twme.debugstickpro.config.ConfigFile;
+
 import java.lang.reflect.Proxy;
 
 import static org.junit.Assert.assertFalse;
@@ -28,6 +30,17 @@ public class BlockDataSeparaterTest {
         assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Door.class)));
         assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(SmallDripleaf.class)));
         assertFalse(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(PitcherCrop.class)));
+    }
+
+    @Test
+    public void allowsUnsafeBisectedPropertiesWhenConfigured() {
+        ConfigFile.BlockDataFilter.AllowUnsafeBisectedData = true;
+        try {
+            assertTrue(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Bisected.class)));
+            assertTrue(BlockDataSeparater.isBisectedHalfSafeToModify(blockData(Door.class)));
+        } finally {
+            ConfigFile.BlockDataFilter.AllowUnsafeBisectedData = false;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stop exposing the `half` property for multi-block `Bisected` block data by default
- preserve valid single-block `half` editing for stairs and trapdoors
- add `BlockDataFilter.AllowUnsafeBisectedData` for servers that intentionally need the original behavior
- add regression coverage for the default and opt-in behavior

## Root cause
DebugStickPro applies block data to only the targeted block with physics disabled. Changing a double plant from its upper half to a lower half can therefore leave two independent lower halves, each of which produces a drop when broken.

The existing configurable blacklist can mitigate this only when explicitly enabled. The shared separation point now protects classic and copy modes by default. Administrators can set `BlockDataFilter.AllowUnsafeBisectedData: true` to restore multi-block `Bisected` editing when that risk is acceptable. Stairs and trapdoors remain available because their `half` property is a valid single-block placement property.

Adding the setting increments the config version to 8, following the project's existing config migration behavior.

## Verification
- `mvn -B test` (4 tests, 0 failures)
- `mvn -B package`
- GitHub Actions build

Fixes #37