### PR TITLE
ci: test the full supported server matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,24 +41,77 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: paper
-            minecraft: 1.19.4
+          - name: paper Java 17
+            id: paper-java17
+            platform: paper
             java: 17
-            mode: mineflayer
-          - platform: folia
-            minecraft: 1.19.4
+            cases: >-
+              1.19.4:mineflayer
+              1.20:startup
+              1.20.1:startup
+              1.20.2:startup
+              1.20.4:mineflayer
+          - name: paper Java 21 (1.20-1.21.4)
+            id: paper-java21-early
+            platform: paper
+            java: 21
+            cases: >-
+              1.20.5:startup
+              1.20.6:mineflayer
+              1.21:startup
+              1.21.1:mineflayer
+              1.21.3:startup
+              1.21.4:startup
+          - name: paper Java 21 (1.21.5-1.21.11)
+            id: paper-java21-late
+            platform: paper
+            java: 21
+            cases: >-
+              1.21.5:startup
+              1.21.6:startup
+              1.21.7:startup
+              1.21.8:startup
+              1.21.9:startup
+              1.21.10:startup
+              1.21.11:startup
+          - name: paper Java 25
+            id: paper-java25
+            platform: paper
+            java: 25
+            cases: >-
+              26.1.1:startup
+              26.1.2:startup
+              26.2:startup
+          - name: folia Java 17
+            id: folia-java17
+            platform: folia
             java: 17
-            mode: mineflayer
-          - platform: paper
-            minecraft: '26.2'
+            cases: >-
+              1.19.4:mineflayer
+              1.20.1:startup
+              1.20.2:startup
+              1.20.4:mineflayer
+          - name: folia Java 21
+            id: folia-java21
+            platform: folia
+            java: 21
+            cases: >-
+              1.20.6:mineflayer
+              1.21.4:startup
+              1.21.5:startup
+              1.21.6:startup
+              1.21.8:startup
+              1.21.11:startup
+          - name: folia Java 25
+            id: folia-java25
+            platform: folia
             java: 25
-            mode: startup
-          - platform: folia
-            minecraft: '26.2'
-            java: 25
-            mode: startup
+            cases: >-
+              26.1.2:startup
+              26.2:startup
 
-    name: ${{ matrix.platform }} ${{ matrix.minecraft }}
+    name: ${{ matrix.name }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
@@ -81,10 +134,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/debugstickpro-e2e
-          key: debugstickpro-${{ matrix.platform }}-${{ matrix.minecraft }}
+          key: debugstickpro-runtime-v2-${{ matrix.id }}
       - name: Run server integration test
         env:
           DSP_E2E_PLATFORM: ${{ matrix.platform }}
-          DSP_E2E_VERSION: ${{ matrix.minecraft }}
-          DSP_E2E_MODE: ${{ matrix.mode }}
-        run: integration/mineflayer/run-server-e2e.sh
+          DSP_E2E_CASES: ${{ matrix.cases }}
+        run: integration/mineflayer/run-version-group.sh

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 
 > Supports Spigot, Paper, and Folia from Minecraft 1.19.4 through 26.2. Paper is the primary platform.
 
-The compatibility matrix is exercised against both ends of the supported range.
-Mineflayer verifies commands, MiniMessage item output, and VirtualEntities display
-spawn/removal on 1.19.4; 26.2 receives startup and plugin-enable tests because
-Mineflayer does not yet support that protocol.
+The compatibility matrix starts every stable Paper and Folia release available
+between 1.19.4 and 26.2. Mineflayer additionally verifies commands, MiniMessage
+item output, and VirtualEntities display spawn/removal at the 1.19, 1.20, and
+1.21 protocol generations. The 26.x releases receive startup and plugin-enable
+tests because Mineflayer does not yet support those protocols.
 ---
 ## Features:
 ### Dynamically display block data:
@@ -117,8 +118,8 @@ Same as regular debugging stick operation:
 - **Spigot, Paper, or Folia 1.19.4-26.2** (Paper is recommended)
 - **[PacketEvents](https://github.com/retrooper/packetevents) 2.13.0+** (Required for v0.5.0+)
 
-Spigot builds are tested locally with the official BuildTools. Paper and Folia
-endpoint tests run for every pull request.
+Spigot protocol checkpoints are tested locally with the official BuildTools.
+The complete stable Paper and Folia version matrix runs for every pull request.
 
 ### Installation Steps
 1. Install [PacketEvents](https://github.com/retrooper/packetevents) if not already installed

--- a/integration/mineflayer/run-version-group.sh
+++ b/integration/mineflayer/run-version-group.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly PLATFORM="${DSP_E2E_PLATFORM:?DSP_E2E_PLATFORM is required}"
+readonly CASES="${DSP_E2E_CASES:?DSP_E2E_CASES is required}"
+
+read -r -a runtime_cases <<<"${CASES}"
+for runtime_case in "${runtime_cases[@]}"; do
+  IFS=: read -r minecraft_version test_mode extra <<<"${runtime_case}"
+  if [[ -z "${minecraft_version}" || -z "${test_mode}" || -n "${extra:-}" ]]; then
+    echo "Invalid DSP_E2E_CASES entry: ${runtime_case}" >&2
+    exit 2
+  fi
+
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::group::${PLATFORM} ${minecraft_version} ${test_mode}"
+  fi
+
+  DSP_E2E_PLATFORM="${PLATFORM}" \
+  DSP_E2E_VERSION="${minecraft_version}" \
+  DSP_E2E_MODE="${test_mode}" \
+  "${PROJECT_DIR}/integration/mineflayer/run-server-e2e.sh"
+
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::endgroup::"
+  fi
+done


### PR DESCRIPTION
## Summary
- start every stable Paper and Folia release from 1.19.4 through 26.2 in CI
- run Mineflayer functional checks at the 1.19, 1.20, and 1.21 protocol generations
- group compatible runtime cases by Java version to keep the matrix maintainable
- document Paper-first runtime coverage and local Spigot BuildTools checkpoints

## Local verification
- JDK 25 Maven build and 8 unit tests
- all stable Paper and Folia versions in the supported range started with DebugStickPro enabled
- Mineflayer command, MiniMessage item, and VirtualEntities spawn/removal checks at protocol checkpoints
- official BuildTools Spigot 1.20.6 functional test and Spigot 1.21.11 startup test
- YAML, shell, Node syntax, and diff checks